### PR TITLE
Allow updating registration without client cert

### DIFF
--- a/mod_lua/v1-register.lua
+++ b/mod_lua/v1-register.lua
@@ -36,7 +36,7 @@ local function test_address(certificate, address, r)
 		return false
 	end
 
-	if certificate ~= ssl:peer():export() then
+	if certificate and certificate ~= ssl:peer():export() then
 		r:write("Unmatching certificate! Is there perhaps another server?\n")
 		return false
 	end
@@ -56,11 +56,6 @@ function handle(r)
 	end
 
 	local certificate = r:subprocess_env_table()["SSL_CLIENT_CERT"]
-	if not certificate then
-		r:write("Missing certificate!")
-		r.status = 496
-		return apache2.OK
-	end
 
 	local requestbody = r:requestbody()
 	local root = xmlutils.get_root(requestbody)
@@ -166,6 +161,13 @@ function handle(r)
 		end
 
 		updated = true
+	elseif not certificate then
+		r:write("Missing client certificate! \z
+		If your certificate is provided by Let's Encrypt, see \z
+		https://github.com/mumble-voip/mumble/issues/7076 for details.\n")
+		r.status = 496
+		database:close()
+		return apache2.OK
 	end
 
 


### PR DESCRIPTION
Allow updating existing (but NOT creating new) public server list registrations without a client certificate for the initial registration request.

Previously, the registration server enforced that the client certificate on the registration request must match the certificate of the Mumble server to which it establishes a test connection. Without this check, it would be possible to maliciously create registrations for servers one does not control. However, updating an existing registration without this check does not create the same vulnerability as the registration request must include the secret password known only to the Mumble server and the registration server, meaning bad actors cannot maliciously update existing registrations.

Recently, Let's Encrypt stopped providing certificates with client authentication. The majority of public Mumble servers with certificates signed by a CA are signed by Let's Encrypt. The result has been that many long-running public servers have disappeared from the public server list.

This change mitigates the problem by allowing registrations to be updated without requiring a certificate with client authentication. This should not create any new problems (for the reason outlined above) and can largely mitigate the problem until a proper solution (which will likely require modification of the mumble server itself) can be created.

This change requires no action from the aforementioned public Mumble servers in order to get them re-listed.